### PR TITLE
Update to use GitLab API v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.7.1 (Unreleased)
 
-- ...
+- Use GitLab API v4
 
 ## 6.7.0 (2023-06-12)
 

--- a/back/taiga_contrib_gitlab_auth/connector.py
+++ b/back/taiga_contrib_gitlab_auth/connector.py
@@ -36,7 +36,7 @@ API_RESOURCES_URLS = {
         "access-token": "oauth/token"
     },
     "user": {
-        "profile": "api/v3/user",
+        "profile": "api/v4/user",
     }
 }
 

--- a/back/tests/unit/test_connectors_gitlab.py
+++ b/back/tests/unit/test_connectors_gitlab.py
@@ -18,7 +18,7 @@ def test_url_builder():
         assert (gitlab._build_url("login", "access-token") ==
                 "http://localhost:4321/oauth/token")
         assert (gitlab._build_url("user", "profile") ==
-                "http://localhost:4321/api/v3/user")
+                "http://localhost:4321/api/v4/user")
 
 
 def test_login_without_settings_params():
@@ -88,7 +88,7 @@ def test_get_user_profile_success():
         assert user_profile.username == "mmcfly"
         assert user_profile.full_name == "martin seamus mcfly"
         assert user_profile.bio == "time traveler"
-        m_requests.get.assert_called_once_with("http://localhost:4321/api/v3/user",
+        m_requests.get.assert_called_once_with("http://localhost:4321/api/v4/user",
                                                headers=gitlab.HEADERS)
 
 


### PR DESCRIPTION
Update the request to recover the user profile from the GitLab's API, to use the official supported version (v4)
https://about.gitlab.com/blog/2018/06/01/api-v3-removal-impending/